### PR TITLE
docker-api gem

### DIFF
--- a/sensu-plugins-docker.gemspec
+++ b/sensu-plugins-docker.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsDocker::Version::VER_STRING
 
-  s.add_runtime_dependency 'docker-api',       '0.0.1'
+  s.add_runtime_dependency 'docker-api',   '~> 1.21'
   s.add_runtime_dependency 'sensu-plugin', '1.1.0'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-docker.gemspec
+++ b/sensu-plugins-docker.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsDocker::Version::VER_STRING
 
-  s.add_runtime_dependency 'docker',       '0.0.1'
+  s.add_runtime_dependency 'docker-api',       '0.0.1'
   s.add_runtime_dependency 'sensu-plugin', '1.1.0'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
The docker gem is now docker-api.  When attempting to use the docker gem nothing functions, but replacing it with docker-api it works.