### PR TITLE
Rework check-container-logs.rb

### DIFF
--- a/bin/check-docker-container.rb
+++ b/bin/check-docker-container.rb
@@ -13,8 +13,7 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: docker
-#   gem: docker-api
+#   gem: net_http_unix
 #
 # USAGE:
 #   check-docker-container.rb -w 3 -c 3
@@ -30,62 +29,81 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'docker'
-
+require 'sensu-plugins-docker/client_helpers'
+require 'json'
 #
 # Check Docker Conatiners
 #
 class CheckDockerContainers < Sensu::Plugin::Check::CLI
-  option :url,
-         short: '-u docker host',
-         default: 'http://127.0.0.1:2376/'
+  option :docker_host,
+         short: '-h docker_host',
+         long: '--host DOCKER_HOST',
+         default: '127.0.0.1:2375'
 
   option :warn_over,
-         short: '-w N',
+         short: '-W N',
          long: '--warn-over N',
          description: 'Trigger a warning if over a number',
          proc: proc(&:to_i)
 
   option :crit_over,
-         short: '-c N',
+         short: '-C N',
          long: '--critical-over N',
          description: 'Trigger a critical if over a number',
          proc: proc(&:to_i)
 
   option :warn_under,
-         short: '-W N',
+         short: '-w N',
          long: '--warn-under N',
          description: 'Trigger a warning if under a number',
          proc: proc(&:to_i),
          default: 1
 
   option :crit_under,
-         short: '-C N',
+         short: '-c N',
          long: '--critical-under N',
          description: 'Trigger a critical if under a number',
          proc: proc(&:to_i),
          default: 1
 
-  def run #rubocop:disable all
-    Docker.url = "#{config[:url]}"
-    conn = Docker::Container.all(running: true)
-    count = conn.size.to_i
-    message "#{count} Running Containers..."
+  def under_message(crit_under, count)
+    "Less than #{crit_under} containers running. #{count} running."
+  end
 
+  def over_message(crit_over, count)
+    "More than #{crit_over} containers running. #{count} running."
+  end
+
+  def evaluate_count(count)
     # #YELLOW
-    if !!config[:crit_under] && count < config[:crit_under] # rubocop:disable Style/DoubleNegation
-      critical
+    if config.key?(:crit_under) && count < config[:crit_under]
+      critical under_message(config[:crit_under], count)
     # #YELLOW
-    elsif !!config[:crit_over] && count > config[:crit_over] # rubocop:disable Style/DoubleNegation
-      critical
+    elsif config.key?(:crit_over) && count > config[:crit_over]
+      critical over_message(config[:crit_over], count)
     # #YELLOW
-    elsif !!config[:warn_under] && count < config[:warn_under] # rubocop:disable Style/DoubleNegation
-      warning
+    elsif config.key?(:warn_under) && count < config[:warn_under]
+      warning under_message(config[:warn_under], count)
     # #YELLOW
-    elsif !!config[:warn_over] && count > config[:warn_over] # rubocop:disable Style/DoubleNegation
-      warning
+    elsif config.key?(:warn_over) && count > config[:warn_over]
+      warning over_message(config[:warn_over], count)
     else
       ok
+    end
+  end
+
+  def run
+    client = create_docker_client
+    path = '/containers/json'
+    req = Net::HTTP::Get.new path
+    begin
+      response = client.request(req)
+      containers = JSON.parse(response.body)
+      evaluate_count containers.size
+    rescue JSON::ParserError => e
+      critical "JSON Error: #{e.inspect}"
+    rescue => e
+      warning "Error: #{e.inspect}"
     end
   end
 end

--- a/lib/sensu-plugins-docker/client_helpers.rb
+++ b/lib/sensu-plugins-docker/client_helpers.rb
@@ -1,0 +1,18 @@
+require 'net_http_unix'
+
+def create_docker_client
+  client = nil
+  if config[:docker_host][0] == '/'
+    host = 'unix://' + config[:docker_host]
+    client = NetX::HTTPUnix.new(host)
+  else
+    split_host = config[:docker_host].split ':'
+    if split_host.length == 2
+      client = NetX::HTTPUnix.new(split_host[0], split_host[1])
+    else
+      client = NetX::HTTPUnix.new(config[:docker_host], 2375)
+    end
+  end
+
+  client
+end


### PR DESCRIPTION
I've made a few adjustments for the check-container-logs.rb check:

* Add an optional parameter to limit the log check to recent failures (-t parameter).
* Refactor to make the protocol parameter unnecessary.
* Remove unnecessary dependencies.