### PR TITLE
issue critical alert if state is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ changes some options. Review your check commands before deploying this version.
 - check-docker-container.rb: output the number of running containers
 - Refactor to connect to the Docker API socket directly instead of using the `docker` or `docker-api` gems
 - Update to rubocop 0.40 and cleanup
+- check-container.rb: issue a critical event if container state 1= running
 
 ## [0.0.4] - 2015-08-10
 ### Changed

--- a/bin/check-container.rb
+++ b/bin/check-container.rb
@@ -62,9 +62,11 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
         critical "#{config[:container]} is not running on #{config[:docker_host]}"
       end
 
-      container_info = JSON.parse(response.body)
-      if container_info['State']['Status'] == 'running'
+      container_state = JSON.parse(response.body)['State']['Status']
+      if container_state == 'running'
         ok "#{config[:container]} is running on #{config[:docker_host]}."
+      else
+        critical "#{config[:container]} is #{container_state} on #{config[:docker_host]}."
       end
     rescue JSON::ParserError => e
       critical "JSON Error: #{e.inspect}"


### PR DESCRIPTION
The documentation for ```check-container.rb``` states that if the container state is not running it will issue a critical event. However it does not issue any exit code.