### PR TITLE
Fix errors from stats that return multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Fixed
-- metrics-docker-stats.rb: Fix error from trying to collect stats with multiple values (#29)
+- metrics-docker-stats.rb: Fix error from trying to collect stats with multiple values. Stats that return array values are now excluded. (#29)
 
 ## [1.1.0] - 2016-06-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-docker-stats.rb: Fix error from trying to collect stats with multiple values (#29)
 
 ## [1.1.0] - 2016-06-03
 ### Added

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -28,7 +28,6 @@
 #   for details.
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
 require 'socket'
 require 'net_http_unix'

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 #
-#   docker-container-metrics
+#   metrics-docker-stats
 #
 # DESCRIPTION:
 #

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -18,7 +18,16 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   #YELLOW
+#   Gather stats from all containers on a host using socket:
+#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock
+#
+#   Gather stats from all containers on a host using TCP:
+#   metrics-docker-stats.rb -p http -H localhost:2375
+#
+#   Gather stats from a specific container using socket:
+#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock -c 5bf1b82382eb
+#
+#   See metrics-docker-stats.rb --help for full usage flags
 #
 # NOTES:
 #

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -106,7 +106,7 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
     dotted_stats = Hash.to_dotted_hash stats
     dotted_stats.each do |key, value|
       next if key == 'read' # unecessary timestamp
-      next if key.start_with? 'blkio_stats' # array values, figure out later
+      next if value.is_a?(Array)
       output "#{config[:scheme]}.#{container}.#{key}", value, @timestamp
     end
   end

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -5,7 +5,7 @@
 # DESCRIPTION:
 #
 # Supports the stats feature of the docker remote api ( docker server 1.5 and newer )
-# Currently only supports when docker is listening on tcp port.
+# Supports connecting to docker remote API over Unix socket or TCP
 #
 #
 # OUTPUT:


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Fixes #29 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Existing tests pass 

#### Purpose

Addresses issue raised in #29 where stats that return multiple values throw an error. Now we skip any stats that return multiple values, currently only `percpu_usage` and `blkio` stats. Also some cleanup and add usage.

#### Known Compatablity Issues

None