### PR TITLE
Improve help message for docker_host option in all scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - metrics-docker-stats.rb: Fix error from trying to collect stats with multiple values. Stats that return array values are now excluded. (#29)
 
+### Changed
+- improved help messages
+
 ## [1.1.0] - 2016-06-03
 ### Added
 - check-container-logs.rb: added `-s|--seconds-ago` option to be able to set time interval more precisely

--- a/bin/check-container-logs.rb
+++ b/bin/check-container-logs.rb
@@ -37,7 +37,7 @@ require 'sensu-plugins-docker/client_helpers'
 
 class ContainerLogChecker < Sensu::Plugin::Check::CLI
   option :docker_host,
-         description: 'location of docker api: host:port or /path/to/docker.sock',
+         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
          default: '127.0.0.1:2375'

--- a/bin/check-container.rb
+++ b/bin/check-container.rb
@@ -46,6 +46,7 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
   option :docker_host,
          short: '-h DOCKER_HOST',
          long: '--host DOCKER_HOST',
+         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
          default: '127.0.0.1:2375'
   option :container,
          short: '-c CONTAINER',

--- a/bin/check-docker-container.rb
+++ b/bin/check-docker-container.rb
@@ -38,6 +38,7 @@ class CheckDockerContainers < Sensu::Plugin::Check::CLI
   option :docker_host,
          short: '-h docker_host',
          long: '--host DOCKER_HOST',
+         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
          default: '127.0.0.1:2375'
 
   option :warn_over,

--- a/bin/metrics-docker-container.rb
+++ b/bin/metrics-docker-container.rb
@@ -46,7 +46,7 @@ class DockerContainerMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: '/sys/fs/cgroup'
 
   option :docker_host,
-         description: 'docker host',
+         description: 'Docker host. TCP: "tcp://host:port" or Unix: "unix:///path/to/docker.sock" (default: "tcp://127.0.1.1:2376")',
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
          default: 'tcp://127.0.1.1:2376'

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -69,7 +69,7 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: ''
 
   option :docker_host,
-         description: 'location of docker api, host:port or /path/to/docker.sock',
+         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
          default: '127.0.0.1:2375'


### PR DESCRIPTION
It was confusing for me how to use docker_host option in different scripts.
Scripts `metrics-docker-container.rb` and `metrics-docker-stats.rb` still require different format / options than others. I've tried to provide clear description.