### PR TITLE
Changes in runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- dependencies: use sensu-plugin ~> 1.2.0, docker-api = 1.21.0
 
 ## [1.1.1] - 2016-06-10
 ### Fixed

--- a/sensu-plugins-docker.gemspec
+++ b/sensu-plugins-docker.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsDocker::Version::VER_STRING
 
-  s.add_runtime_dependency 'docker-api',    '1.21'
-  s.add_runtime_dependency 'sensu-plugin',  '1.2.0'
+  s.add_runtime_dependency 'docker-api',    '1.21.0'
+  s.add_runtime_dependency 'sensu-plugin',  '~> 1.2.0'
   s.add_runtime_dependency 'sys-proctable', '0.9.8'
   s.add_runtime_dependency 'net_http_unix', '0.2.1'
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

#### Purpose

- `sensu-plugin` – sensu packages are now shipped with sensu-plugin 1.3.0 [(sensu #1339)](https://github.com/sensu/sensu/issues/1339)
- `docker-api` – it actually installed 1.21.0 when using gem install, but for RPM built from this gem it caused a broken dependency error

#### Known Compatablity Issues


