### PR TITLE
updating net_http_unix dependency version to be compatible with ruby 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Changed
+
+- dependencies: use net\_http\_unix = 0.2.2
+
+
 ## [1.1.2] - 2016-06-20
 ### Changed
 - dependencies: use sensu-plugin ~> 1.2.0, docker-api = 1.21.0

--- a/sensu-plugins-docker.gemspec
+++ b/sensu-plugins-docker.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'docker-api',    '1.21.0'
   s.add_runtime_dependency 'sensu-plugin',  '~> 1.2.0'
   s.add_runtime_dependency 'sys-proctable', '0.9.8'
-  s.add_runtime_dependency 'net_http_unix', '0.2.1'
+  s.add_runtime_dependency 'net_http_unix', '0.2.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
The version bump for `net_http_unix` corrects a deprecation error encountered with the  `Timeout` library when using ruby 2.3. 

This closes #40, #30 

The PR for the `net_http_unix` fix is here: https://github.com/puppetlabs/net_http_unix/pull/1