### PR TITLE
add basic ability to split a docker name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- metrics-docker-stats.rb: Add an option to ouput a portion of the docker
+  container name using by splitting on a delimiter of the users choice.
 
 ## [1.2.0] - 2017-02-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.2.1] - 2017-02-08
+### Added
+- metrics-docker-stats.rb: Add an option to ouput a position of the docker
+  container name using by splitting on a delimiter of the users choice.
+
 ## [1.2.0] - 2017-02-08
 ### Added
 - check-container.rb: add an option to test image's tag (@obazoud)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## [1.2.1] - 2017-02-08
-### Added
-- metrics-docker-stats.rb: Add an option to ouput a position of the docker
-  container name using by splitting on a delimiter of the users choice.
-
 ## [1.2.0] - 2017-02-08
 ### Added
 - check-container.rb: add an option to test image's tag (@obazoud)

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -87,6 +87,18 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          boolean: true,
          default: false
 
+  option :name_part,
+         description: 'Partial name by spliting and returning at index. eg. -m 3 my-docker-container-process_name-b2ffdab8f1aceae85300 for process_name',
+         short: '-m index',
+         long: '--match index',
+         default: ''
+
+  option :delim,
+         description: 'the deliminator to use with -m',
+         short: '-d',
+         long: '--deliminator',
+         default: '-'
+
   def run
     @timestamp = Time.now.to_i
 
@@ -97,6 +109,9 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
            end
     list.each do |container|
       stats = container_stats(container)
+      if config[:name_part]
+        container = container.split(config[:delim])[config[:name_part].to_i]
+      end
       output_stats(container, stats)
     end
     ok
@@ -136,6 +151,8 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     @containers.each do |container|
       list << if config[:friendly_names]
+                container['Names'][0].delete('/')
+              elsif config[:name_part]
                 container['Names'][0].delete('/')
               else
                 container['Id']

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -88,7 +88,8 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: false
 
   option :name_parts,
-         description: 'Partial names by spliting and returning at index(es). eg. -m 3,4 my-docker-container-process_name-b2ffdab8f1aceae85300 for process_name.b2ffdab8f1aceae85300',
+         description: 'Partial names by spliting and returning at index(es). \
+                       eg. -m 3,4 my-docker-container-process_name-b2ffdab8f1aceae85300 for process_name.b2ffdab8f1aceae85300',
          short: '-m index',
          long: '--match index'
 

--- a/lib/sensu-plugins-docker/version.rb
+++ b/lib/sensu-plugins-docker/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsDocker
   module Version
     MAJOR = 1
     MINOR = 2
-    PATCH = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-docker/version.rb
+++ b/lib/sensu-plugins-docker/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsDocker
   module Version
     MAJOR = 1
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

#### Purpose

We use long docker names such as:

ecs-fc-prod-deploy-for-periodic_task_agent-4-deploy-for-alteration16-periodictaskagent-b2ffdab8f1aceae85300

This enables the metrics plugin to split the names on a delimiter and output stats in a potentially more useful namespace. 

```
$ ./metrics-docker-stats.rb --scheme sensu.docker -p unix -H /var/run/docker.sock -m 5

sensu.docker.periodic_task_agent.networks.eth0.rx_packets 52281 1494943538

```