### PR TITLE
Update check-container.rb

### DIFF
--- a/bin/check-container.rb
+++ b/bin/check-container.rb
@@ -62,7 +62,7 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
     req = Net::HTTP::Get.new path
     begin
       response = client.request(req)
-      if response.body.include? 'no such id'
+      if response.code.to_i == 404
         critical "#{config[:container]} is not running on #{config[:docker_host]}"
       end
       body = JSON.parse(response.body)
@@ -77,7 +77,7 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
         end
         ok "#{config[:container]} is running on #{config[:docker_host]}."
       else
-        critical "#{config[:container]} is #{container_state} on #{config[:docker_host]}."
+        critical "#{config[:container]} is #{body['State']['Status']} on #{config[:docker_host]}."
       end
     rescue JSON::ParserError => e
       critical "JSON Error: #{e.inspect}"


### PR DESCRIPTION
I got this two problems:

WARNING: Error: #<NameError: undefined local variable or method `container_state' for #<CheckDockerContainer:0x0000000202c428>

container_state had no prior declaration.

response.body.include? 'no such id' 
I got this message: "{\"message\":\"No such container: e941be33c527\"}\n" 
Which always returned this error, 
 #<NoMethodError: undefined method `[]' for nil:NilClass>

So i test if we'll always get 404 if a container does not exist. Everythink went ok.

CheckDockerContainer CRITICAL: e941be33c527 is not running on /var/run/docker.sock