### PR TITLE
Adding io metrics collection, environment values into metric name and general docker info stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+### Added
+- metrics-docker-info.rb: general information metrics from docker
+- metrics-docker-stats.rb: Added to include environment variables values as part of the metric. Added I/O stats option
+
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-### Added
+## [Unreleased]
 - metrics-docker-info.rb: general information metrics from docker
 - metrics-docker-stats.rb: Added to include environment variables values as part of the metric. Added I/O stats option
 
-## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This check supports docker versions >= 1.18. Check docker-engine API for more in
  * check-docker-container.rb
  * metrics-docker-container.rb
  * metrics-docker-stats.rb
+ * metrics-docker-info.rb
 
 ## Usage
 

--- a/bin/metrics-docker-info.rb
+++ b/bin/metrics-docker-info.rb
@@ -1,0 +1,105 @@
+#! /usr/bin/env ruby
+#
+#   metrics-docker-stats
+#
+# DESCRIPTION:
+#
+# Supports the stats feature of the docker remote api ( docker server 1.5 and newer )
+# Supports connecting to docker remote API over Unix socket or TCP
+#
+#
+# OUTPUT:
+#   metric-data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   Gather stats from all containers on a host using socket:
+#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock
+#
+#   Gather stats from all containers on a host using TCP:
+#   metrics-docker-stats.rb -p http -H localhost:2375
+#
+#   Gather stats from a specific container using socket:
+#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock -c 5bf1b82382eb
+#
+#   See metrics-docker-stats.rb --help for full usage flags
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015 Paul Czarkowski. Github @paulczar
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'socket'
+require 'net_http_unix'
+require 'json'
+
+class Hash
+  def self.to_dotted_hash(hash, recursive_key = '')
+    hash.each_with_object({}) do |(k, v), ret|
+      key = recursive_key + k.to_s
+      if v.is_a? Hash
+        ret.merge! to_dotted_hash(v, key + '.')
+      else
+        ret[key] = v
+      end
+    end
+  end
+end
+
+class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.docker"
+
+  option :docker_host,
+         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
+         short: '-H DOCKER_HOST',
+         long: '--docker-host DOCKER_HOST',
+         default: '127.0.0.1:2375'
+
+  option :docker_protocol,
+         description: 'http or unix',
+         short: '-p PROTOCOL',
+         long: '--protocol PROTOCOL',
+         default: 'http'
+
+  def run
+    @timestamp = Time.now.to_i
+    path = 'info'
+    infolist = docker_api(path)
+    filtered_list = infolist.select { |key, _value| key.match(/NCPU|NFd|Containers|Images|NGoroutines|NEventsListener|MemTotal/) }
+    filtered_list.each do |key, value|
+      output "#{config[:scheme]}.#{key}", value, @timestamp
+    end
+    ok
+  end
+
+  def docker_api(path)
+    if config[:docker_protocol] == 'unix'
+      session = NetX::HTTPUnix.new("unix://#{config[:docker_host]}")
+      request = Net::HTTP::Get.new "/#{path}"
+    else
+      uri = URI("#{config[:docker_protocol]}://#{config[:docker_host]}/#{path}")
+      session = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Get.new uri.request_uri
+    end
+
+    session.start do |http|
+      http.request request do |response|
+        response.value
+        return JSON.parse(response.read_body)
+      end
+    end
+  end
+end

--- a/bin/metrics-docker-info.rb
+++ b/bin/metrics-docker-info.rb
@@ -42,19 +42,6 @@ require 'socket'
 require 'net_http_unix'
 require 'json'
 
-class Hash
-  def self.to_dotted_hash(hash, recursive_key = '')
-    hash.each_with_object({}) do |(k, v), ret|
-      key = recursive_key + k.to_s
-      if v.is_a? Hash
-        ret.merge! to_dotted_hash(v, key + '.')
-      else
-        ret[key] = v
-      end
-    end
-  end
-end
-
 class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',

--- a/bin/metrics-docker-info.rb
+++ b/bin/metrics-docker-info.rb
@@ -59,7 +59,7 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'http or unix',
          short: '-p PROTOCOL',
          long: '--protocol PROTOCOL',
-         default: 'http'
+         default: 'unix'
 
   def run
     @timestamp = Time.now.to_i

--- a/bin/metrics-docker-info.rb
+++ b/bin/metrics-docker-info.rb
@@ -1,11 +1,13 @@
 #! /usr/bin/env ruby
 #
-#   metrics-docker-stats
+#   metrics-docker-info
 #
 # DESCRIPTION:
 #
+# This check gather certain general stats from Docker (number of CPUs, number of containers, images...)
 # Supports the stats feature of the docker remote api ( docker server 1.5 and newer )
 # Supports connecting to docker remote API over Unix socket or TCP
+# Based on metrics-docker-stats by @paulczar
 #
 #
 # OUTPUT:
@@ -18,21 +20,18 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   Gather stats from all containers on a host using socket:
-#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock
+#   Gather stats using unix socket:
+#   metrics-docker-info.rb -p unix -H /var/run/docker.sock
 #
-#   Gather stats from all containers on a host using TCP:
-#   metrics-docker-stats.rb -p http -H localhost:2375
+#   Gather stats from localhost using TCP:
+#   metrics-docker-info.rb -p http -H localhost:2375
 #
-#   Gather stats from a specific container using socket:
-#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock -c 5bf1b82382eb
-#
-#   See metrics-docker-stats.rb --help for full usage flags
+#   See metrics-docker-info.rb --help for full usage flags
 #
 # NOTES:
 #
 # LICENSE:
-#   Copyright 2015 Paul Czarkowski. Github @paulczar
+#   Copyright 2017 Alfonso Casimiro. Github @alcasim
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
@@ -53,7 +52,7 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
-         default: '127.0.0.1:2375'
+         default: '/var/run/docker.sock'
 
   option :docker_protocol,
          description: 'http or unix',


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Adding metrics-docker-info.rb with general information related to Docker (total number of containers, images, go routines, file descriptors...). These metrics mimics how telegraf gathers information from the docker plugin, and can be useful for people evaluating Sensu as source for their metrics.

In metrics-docker-stats.rb I have added two features:
io metric collection from docker virtual devices, in telegraf style also
Including some environment variables values into the metric (another feature from telegraf).

Please find some output for these changes in https://gist.github.com/alcasim/d21be7ff09d519d5aadb9d5d8215ec86

Also those changes performed on existing metric check (metrics-docker-stats.rb) are optional, so users won't be affected by including new flags into the checks

#### Known Compatability Issues

