### PR TITLE
Adding cpu percentage calculation in metrics-docker-stats.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- metrics-docker-stats.rb: Include metric with cpu usage percentage calculated based on docker stats (@alcasim)
 
 ## [1.4.0] - 2017-08-08
 ### Added

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -231,6 +231,6 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
       number_of_cpu = stats['cpu_stats']['cpu_usage']['percpu_usage'].length
       cpu_percent = (cpu_delta.to_f / system_delta.to_f) * number_of_cpu * 100
     end
-    cpu_percent
+    format('%.2f', cpu_percent)
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Calculating percentage of CPU Usage based on metrics from Docker API it's tough and most of times not possible, as involves some operations which are not always supported (like InfluxDB, it's not posible to count number of metrics to be used as part of an arithmetical operation). I'm adding this metric to metrics-docker-stats.rb with a config flag so accessing to this metric will be much easier.

An example of the output in this gist: https://gist.github.com/alcasim/b385f178e1af5879760f9d28a62bc8a6

#### Known Compatibility Issues
