### PR TITLE
New class to call docker api, check-container-logs.rb features added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 - metrics-docker-stats.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
 - metrics-docker-info.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
 - metrics-docker-container.rb: Make use of DockerApi class. Re-enable rubocop for container_metrics method.
+- check-container.rb: Make use of DockerApi class.
 
 ### Fixed
 - metrics-docker-stats.rb: Remove trailing / in name value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Breaking Change
 - bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
 - Default docker host defined by DockerApi Class ( ENV[DOCKER_URL] => ENV[DOCKER_HOST] => /var/run/docker.sock )
-- check-container-logs.rb: -N (--container-name) instead of -n for container name
+- check-container-logs.rb: -N (--container-name) instead of -n for container name. Now a 'CRITICAL' is trigger if a container doesn't exist (previously, a 'OK' was trigger)
 - check-docker-container.rb: -H (--docker-host) instead of -h (--host) for docker Host
 - check-container.rb: -H (--docker-host) for docker Host instead of -h (--host) for docker host, -N (--container-name) instead of -c (--container) for container name
 - metrics-docker-stats.rb: -N (--container-name) instead of -c (--container) for Container name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Breaking Change
 - bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
 
+### Removed
+- Remove unnecessary `docker_api` dependency
+
 ## [1.5.0] - 2017-09-09
 ### Added
 - metrics-docker-stats.rb: Include metric with cpu usage percentage calculated based on docker stats (@alcasim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Added
 - client_helpers.rb: Add a simple DockerApi class. Add parse_json method.
 
+### Changed
+- metrics-docker-stats.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
+
+### Fixed
+- metrics-docker-stats.rb: Remove trailing / in name value.
+
 ### Removed
 - Remove unnecessary `docker_api` dependency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ### Added
 - client_helpers.rb: Add a simple DockerApi class. Add parse_json method.
+- metrics-docker-container.rb: Friendly names option added
 
 ### Changed
 - metrics-docker-stats.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
+- metrics-docker-info.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
+- metrics-docker-container.rb: Make use of DockerApi class. Re-enable rubocop for container_metrics method.
 
 ### Fixed
 - metrics-docker-stats.rb: Remove trailing / in name value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Added
 - client_helpers.rb: Add a simple DockerApi class. Add parse_json method.
 - metrics-docker-container.rb: Friendly names option added
+- check-container-logs.rb: Add an option to check logs from stopped containers if all containers are checked. Add an option to don't check stderr logs. Add an option to don't check stdout logs. Add timestamp in logs output. Add the possibility to use -n multiple times to check multiple containers at once.
 
 ### Changed
 - metrics-docker-stats.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
@@ -23,12 +24,14 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 - metrics-docker-container.rb: Make use of DockerApi class. Re-enable rubocop for container_metrics method.
 - check-container.rb: Make use of DockerApi class.
 - check-docker-container.rb: Make use of DockerApi class.
+- check-container-logs.rb: Make use of DockerApi class. Check only logs generated with the 8 bits control to prevent to check logs generated in interactive mode. Check the newest logs rows first instead the oldest. Option -n is not required anymore, if -n option is not provided, the check will be applied to all running containers. Changed the messages displayed with ok and critical
 
 ### Fixed
 - metrics-docker-stats.rb: Remove trailing / in name value.
 
 ### Removed
 - Remove unnecessary `docker_api` dependency
+- check-container-logs.rb: Logs generated in interactive mode are not checked anymore
 
 ## [1.5.0] - 2017-09-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ### Breaking Change
 - bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
+- check-container-logs.rb: -N (--container-name) instead of -n for container name
+- check-docker-container.rb: -H (--docker-host) instead of -h (--host) for docker Host
+- check-container.rb: -H (--docker-host) for docker Host instead of -h (--host) for docker host, -N (--container-name) instead of -c (--container) for container name
+- metrics-docker-stats.rb: -N (--container-name) instead of -c (--container) for Container name
 
 ### Added
 - client_helpers.rb: Add a simple DockerApi class. Add parse_json method.
@@ -32,6 +36,8 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Removed
 - Remove unnecessary `docker_api` dependency
 - check-container-logs.rb: Logs generated in interactive mode are not checked anymore
+- metrics-docker-stats.rb: option -p (--protocol) have been removed because new DockerApi don't use it
+- metrics-docker-info.rb: option -p (--protocol) have been removed because new DockerApi don't use it
 
 ## [1.5.0] - 2017-09-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 - metrics-docker-info.rb: Make use of DockerApi class. Default docker_host defined by DockerApi class. Remove docker_api method.
 - metrics-docker-container.rb: Make use of DockerApi class. Re-enable rubocop for container_metrics method.
 - check-container.rb: Make use of DockerApi class.
+- check-docker-container.rb: Make use of DockerApi class.
 
 ### Fixed
 - metrics-docker-stats.rb: Remove trailing / in name value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Breaking Change
 - bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
 
+### Added
+- client_helpers.rb: Add a simple DockerApi class. Add parse_json method.
+
 ### Removed
 - Remove unnecessary `docker_api` dependency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ### Breaking Change
 - bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
+- Default docker host defined by DockerApi Class ( ENV[DOCKER_URL] => ENV[DOCKER_HOST] => /var/run/docker.sock )
 - check-container-logs.rb: -N (--container-name) instead of -n for container name
 - check-docker-container.rb: -H (--docker-host) instead of -h (--host) for docker Host
 - check-container.rb: -H (--docker-host) for docker Host instead of -h (--host) for docker host, -N (--container-name) instead of -c (--container) for container name

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ This check supports docker versions >= 1.18. Check docker-engine API for more in
 
 ## Usage
 
+### Default docker host
+By default, all the checks will try to use a default docker host if a specific docker host is not provided to the check on the command line (-H <docker_host> / --docker-host <docker_host>).
+
+Those paramaters will be tried in this order as default docker host :
+
+    DOCKER_URL environnement variable
+    DOCKER_HOST environnement variable
+    /var/run/docker.sock file
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/bin/check-container-logs.rb
+++ b/bin/check-container-logs.rb
@@ -17,9 +17,20 @@
 #   gem: net_http_unix
 #
 # USAGE:
-#   check-container-logs.rb -H /tmp/docker.sock -n logspout -r 'problem sending' -r 'i/o timeout' -i 'Remark:' -i 'The configuration is'
+#   # Check only one container
+#   check-container-logs.rb -H /tmp/docker.sock -N logspout -r 'problem sending' -r 'i/o timeout' -i 'Remark:' -i 'The configuration is'
 #   => 1 container running = OK
 #   => 4 container running = CRITICAL
+#
+#   # Check multiple containers
+#   check-container-logs.rb -H /tmp/docker.sock -N logspout -N logtest -r 'problem sending' -r 'i/o timeout' -i 'Remark:' -i 'The configuration is'
+#   => 1 container running = OK
+#   => 4 container running = CRITICAL
+#
+#   # Check all containers
+#   check-container-logs.rb -H /tmp/docker.sock -r 'problem sending' -r 'i/o timeout' -i 'Remark:' -i 'The configuration is'
+#   => 1 containers running = OK
+#   => 4 containers running = CRITICAL
 #
 # NOTES:
 #   The API parameter required to use the limited lookback (-t) was introduced
@@ -44,7 +55,7 @@ class ContainerLogChecker < Sensu::Plugin::Check::CLI
 
   option :container,
          description: 'name of container; can be used multiple times. /!\ All running containers will be check if this options is not provided',
-         short: '-n CONTAINER',
+         short: '-N CONTAINER',
          long: '--container-name CONTAINER',
          default: [],
          proc: proc { |flag| (@options[:container][:accumulated] ||= []).push(flag) }

--- a/bin/check-container-logs.rb
+++ b/bin/check-container-logs.rb
@@ -50,8 +50,7 @@ class ContainerLogChecker < Sensu::Plugin::Check::CLI
   option :docker_host,
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          short: '-H DOCKER_HOST',
-         long: '--docker-host DOCKER_HOST',
-         default: '127.0.0.1:2375'
+         long: '--docker-host DOCKER_HOST'
 
   option :container,
          description: 'name of container; can be used multiple times. /!\ All running containers will be check if this options is not provided',
@@ -61,16 +60,16 @@ class ContainerLogChecker < Sensu::Plugin::Check::CLI
          proc: proc { |flag| (@options[:container][:accumulated] ||= []).push(flag) }
 
   option :red_flags,
-         description: 'substring whose presence (case-insensitive by default) in a log line indicates an error; can be used multiple times',
-         short: '-r "error occurred" -r "problem encountered" -r "error status"',
-         long: '--red-flag "error occurred" --red-flag "problem encountered" --red-flag "error status"',
+         description: 'String whose presence (case-insensitive by default) in a log line indicates an error; can be used multiple times',
+         short: '-r ERR_STRING',
+         long: '--red-flag ERR_STRING',
          default: [],
          proc: proc { |flag| (@options[:red_flags][:accumulated] ||= []).push(flag) }
 
   option :ignore_list,
-         description: 'substring whose presence (case-insensitive by default) in a log line indicates the line should be ignored; can be used multiple times',
-         short: '-i "configuration:" -i "# Remark:"',
-         long: '--ignore-lines-with "configuration:" --ignore-lines-with "# remark:"',
+         description: 'String whose presence (case-insensitive by default) in a log line indicates the line should be ignored; can be used multiple times',
+         short: '-i IGNSTR',
+         long: '--ignore-lines-with IGNSTR',
          default: [],
          proc: proc { |flag| (@options[:ignore_list][:accumulated] ||= []).push(flag) }
 

--- a/bin/check-container-logs.rb
+++ b/bin/check-container-logs.rb
@@ -175,6 +175,13 @@ class ContainerLogChecker < Sensu::Plugin::Check::CLI
     problem_string = nil
     path = "/containers/json?all=#{config[:check_all]}"
     containers = config[:container]
+    if config[:container].none?
+      warn_msg = %(
+        Collecting logs from all containers is dangerous and could lead to sensu client hanging depending on volume of logs.
+        This not recommended for production environments.
+      ).gsub(/\s+/, ' ').strip
+      message warn_msg
+    end
     containers = @client.parse(path).map { |p| p['Names'][0].delete('/') } if containers.none?
     critical 'Check all containers was asked but no containers was found' if containers.none?
     containers.each do |container|

--- a/bin/check-container.rb
+++ b/bin/check-container.rb
@@ -37,7 +37,6 @@
 
 require 'sensu-plugin/check/cli'
 require 'sensu-plugins-docker/client_helpers'
-require 'json'
 
 #
 # Check Docker Container
@@ -46,8 +45,9 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
   option :docker_host,
          short: '-h DOCKER_HOST',
          long: '--host DOCKER_HOST',
-         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
+         description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          default: '127.0.0.1:2375'
+
   option :container,
          short: '-c CONTAINER',
          long: '--container CONTAINER',
@@ -57,32 +57,25 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
          long: '--tag TAG'
 
   def run
-    client = create_docker_client
+    @client = DockerApi.new(config[:docker_host])
     path = "/containers/#{config[:container]}/json"
-    req = Net::HTTP::Get.new path
-    begin
-      response = client.request(req)
-      if response.code.to_i == 404
-        critical "#{config[:container]} is not running on #{config[:docker_host]}"
-      end
-      body = JSON.parse(response.body)
-      container_running = body['State']['Running']
-      if container_running
-        if config[:tag]
-          image = body['Config']['Image']
-          match = image.match(/^(?:([^\/]+)\/)?(?:([^\/]+)\/)?([^@:\/]+)(?:[@:](.+))?$/)
-          unless match && match[4] == config[:tag]
-            critical "#{config[:container]}'s tag is '#{match[4]}', excepting '#{config[:tag]}'"
-          end
+    response = @client.call(path, false)
+    if response.code.to_i == 404
+      critical "Container #{config[:container]} is not running on #{@client.uri}"
+    end
+    body = parse_json(response)
+    container_running = body['State']['Running']
+    if container_running
+      if config[:tag]
+        image = body['Config']['Image']
+        match = image.match(/^(?:([^\/]+)\/)?(?:([^\/]+)\/)?([^@:\/]+)(?:[@:](.+))?$/)
+        unless match && match[4] == config[:tag]
+          critical "#{config[:container]}'s tag is '#{match[4]}', especting '#{config[:tag]}'"
         end
-        ok "#{config[:container]} is running on #{config[:docker_host]}."
-      else
-        critical "#{config[:container]} is #{body['State']['Status']} on #{config[:docker_host]}."
       end
-    rescue JSON::ParserError => e
-      critical "JSON Error: #{e.inspect}"
-    rescue => e
-      warning "Error: #{e.inspect}"
+      ok "#{config[:container]} is running on #{@client.uri}."
+    else
+      critical "#{config[:container]} is #{body['State']['Status']} on #{@client.uri}."
     end
   end
 end

--- a/bin/check-container.rb
+++ b/bin/check-container.rb
@@ -16,11 +16,11 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   check-container.rb -h /var/run/docker.sock -c c92d402a5d14
+#   check-container.rb -H /var/run/docker.sock -N c92d402a5d14
 #   CheckDockerContainer OK: c92d402a5d14 is running on /var/run/docker.sock.
 #
-#   check-container.rb -h /var/run/docker.sock -c circle_burglar
-#   CheckDockerContainer CRITICAL: circle_burglar is not running on /var/run/docker.sock
+#   check-container.rb -H https://127.0.0.1:2376 -N circle_burglar
+#   CheckDockerContainer CRITICAL: circle_burglar is not running on https://127.0.0.1:2376
 #
 # NOTES:
 #     => State.running == true   -> OK
@@ -43,15 +43,16 @@ require 'sensu-plugins-docker/client_helpers'
 #
 class CheckDockerContainer < Sensu::Plugin::Check::CLI
   option :docker_host,
-         short: '-h DOCKER_HOST',
-         long: '--host DOCKER_HOST',
+         short: '-H DOCKER_HOST',
+         long: '--docker-host DOCKER_HOST',
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          default: '127.0.0.1:2375'
 
   option :container,
-         short: '-c CONTAINER',
-         long: '--container CONTAINER',
+         short: '-N CONTAINER',
+         long: '--container-name CONTAINER',
          required: true
+
   option :tag,
          short: '-t TAG',
          long: '--tag TAG'

--- a/bin/check-container.rb
+++ b/bin/check-container.rb
@@ -45,8 +45,7 @@ class CheckDockerContainer < Sensu::Plugin::Check::CLI
   option :docker_host,
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
-         description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
-         default: '127.0.0.1:2375'
+         description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path'
 
   option :container,
          short: '-N CONTAINER',

--- a/bin/check-docker-container.rb
+++ b/bin/check-docker-container.rb
@@ -46,8 +46,7 @@ class CheckDockerContainers < Sensu::Plugin::Check::CLI
   option :docker_host,
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          short: '-H DOCKER_HOST',
-         long: '--docker-host DOCKER_HOST',
-         default: '127.0.0.1:2375'
+         long: '--docker-host DOCKER_HOST'
 
   option :warn_over,
          short: '-W N',

--- a/bin/check-docker-container.rb
+++ b/bin/check-docker-container.rb
@@ -30,7 +30,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'sensu-plugins-docker/client_helpers'
-require 'json'
+
 #
 # Check Docker Containers
 #
@@ -38,7 +38,7 @@ class CheckDockerContainers < Sensu::Plugin::Check::CLI
   option :docker_host,
          short: '-h docker_host',
          long: '--host DOCKER_HOST',
-         description: 'Docker socket to connect. TCP: "host:port" or Unix: "/path/to/docker.sock" (default: "127.0.0.1:2375")',
+         description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          default: '127.0.0.1:2375'
 
   option :warn_over,
@@ -94,17 +94,8 @@ class CheckDockerContainers < Sensu::Plugin::Check::CLI
   end
 
   def run
-    client = create_docker_client
-    path = '/containers/json'
-    req = Net::HTTP::Get.new path
-    begin
-      response = client.request(req)
-      containers = JSON.parse(response.body)
-      evaluate_count containers.size
-    rescue JSON::ParserError => e
-      critical "JSON Error: #{e.inspect}"
-    rescue => e
-      warning "Error: #{e.inspect}"
-    end
+    @client = DockerApi.new(config[:docker_host])
+    containers = @client.parse('/containers/json')
+    evaluate_count containers.size
   end
 end

--- a/bin/check-docker-container.rb
+++ b/bin/check-docker-container.rb
@@ -20,6 +20,14 @@
 #   => 1 container running = OK.
 #   => 4 container running = CRITICAL
 #
+#   check-docker-container.rb -H /var/run/docker.sock -w 3 -c 3
+#   => 1 container running = OK.
+#   => 4 container running = CRITICAL
+#
+#   check-docker-container.rb -H https://127.0.0.1:2376  -w 3 -c 3
+#   => 1 container running = OK.
+#   => 4 container running = CRITICAL
+#
 # NOTES:
 #
 # LICENSE:
@@ -36,9 +44,9 @@ require 'sensu-plugins-docker/client_helpers'
 #
 class CheckDockerContainers < Sensu::Plugin::Check::CLI
   option :docker_host,
-         short: '-h docker_host',
-         long: '--host DOCKER_HOST',
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
+         short: '-H DOCKER_HOST',
+         long: '--docker-host DOCKER_HOST',
          default: '127.0.0.1:2375'
 
   option :warn_over,

--- a/bin/metrics-docker-container.rb
+++ b/bin/metrics-docker-container.rb
@@ -25,7 +25,7 @@
 #
 
 require 'sensu-plugin/metric/cli'
-require 'socket'
+require 'sensu-plugins-docker/client_helpers'
 require 'pathname'
 require 'sys/proctable'
 
@@ -46,7 +46,7 @@ class DockerContainerMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: '/sys/fs/cgroup'
 
   option :docker_host,
-         description: 'Docker host. TCP: "tcp://host:port" or Unix: "unix:///path/to/docker.sock" (default: "tcp://127.0.1.1:2376")',
+         description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
          default: 'tcp://127.0.1.1:2376'
@@ -57,12 +57,20 @@ class DockerContainerMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--cgroup-template template_string',
          default: 'cpu/docker/%{container}/cgroup.procs'
 
+  option :friendly_names,
+         description: 'use friendly name if available',
+         short: '-n',
+         long: '--names',
+         boolean: true,
+         default: false
+
   def run
+    @client = DockerApi.new(config[:docker_host])
     container_metrics
     ok
   end
 
-  def container_metrics #rubocop:disable all
+  def container_metrics
     cgroup = "#{config[:cgroup_path]}/#{config[:cgroup_template]}"
 
     timestamp = Time.now.to_i
@@ -72,18 +80,24 @@ class DockerContainerMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     fields = [:rss, :vsize, :nswap, :pctmem]
 
-    ENV['DOCKER_HOST'] = config[:docker_host]
-    containers = `docker ps --quiet --no-trunc`.split("\n")
+    path = '/containers/json'
+    containers = @client.parse(path)
 
     containers.each do |container|
-      path = Pathname(format(cgroup, container: container))
+      path = Pathname(format(cgroup, container: container['Id']))
       pids = path.readlines.map(&:to_i)
+
+      container_name = if config[:friendly_names]
+                         container['Names'][0].delete('/')
+                       else
+                         container['Id']
+                       end
 
       processes = ps.values_at(*pids).flatten.compact.group_by(&:comm)
       processes2 = ps2.values_at(*pids).flatten.compact.group_by(&:comm)
 
       processes.each do |comm, process|
-        prefix = "#{config[:scheme]}.#{container}.#{comm}"
+        prefix = "#{config[:scheme]}.#{container_name}.#{comm}"
         fields.each do |field|
           output "#{prefix}.#{field}", process.map(&field).reduce(:+), timestamp
         end

--- a/bin/metrics-docker-container.rb
+++ b/bin/metrics-docker-container.rb
@@ -63,13 +63,12 @@ class DockerContainerMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :docker_host,
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          short: '-H DOCKER_HOST',
-         long: '--docker-host DOCKER_HOST',
-         default: 'tcp://127.0.1.1:2376'
+         long: '--docker-host DOCKER_HOST'
 
   option :cgroup_template,
          description: 'cgroup_template',
-         short: '-T <template string>',
-         long: '--cgroup-template template_string',
+         short: '-T TPL_STRING',
+         long: '--cgroup-template TPL_STRING',
          default: 'cpu/docker/%{container}/cgroup.procs'
 
   option :friendly_names,

--- a/bin/metrics-docker-container.rb
+++ b/bin/metrics-docker-container.rb
@@ -14,7 +14,22 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   #YELLOW
+#
+# metrics-docker-container.rb -H /var/run/docker.sock -n
+#   docker.host.sensu.sh.rss 1 1508825823
+#   docker.host.sensu.sh.vsize 1572864 1508825823
+#   docker.host.sensu.sh.nswap 0 1508825823
+#   docker.host.sensu.sh.pctmem 0.0 1508825823
+#   docker.host.sensu.sh.fd 0 1508825823
+#   docker.host.sensu.sh.cpu 0 1508825823
+#
+# metrics-docker-container.rb -H https://127.0.0.1:2376
+#   docker.host.ff5240e079488d248c021f8da5d13074a6a9db72ffaf1129eded445f4e16cf50.sh.rss 183 1508825793
+#   docker.host.ff5240e079488d248c021f8da5d13074a6a9db72ffaf1129eded445f4e16cf50.sh.vsize 4616192 1508825793
+#   docker.host.ff5240e079488d248c021f8da5d13074a6a9db72ffaf1129eded445f4e16cf50.sh.nswap 0 1508825793
+#   docker.host.ff5240e079488d248c021f8da5d13074a6a9db72ffaf1129eded445f4e16cf50.sh.pctmem 0.01 1508825793
+#   docker.host.ff5240e079488d248c021f8da5d13074a6a9db72ffaf1129eded445f4e16cf50.sh.fd 0 1508825793
+#   docker.host.ff5240e079488d248c021f8da5d13074a6a9db72ffaf1129eded445f4e16cf50.sh.cpu 0 1508825793
 #
 # NOTES:
 #

--- a/bin/metrics-docker-info.rb
+++ b/bin/metrics-docker-info.rb
@@ -21,10 +21,10 @@
 #
 # USAGE:
 #   Gather stats using unix socket:
-#   metrics-docker-info.rb -p unix -H /var/run/docker.sock
+#   metrics-docker-info.rb -H /var/run/docker.sock
 #
-#   Gather stats from localhost using TCP:
-#   metrics-docker-info.rb -p http -H localhost:2375
+#   Gather stats from localhost using HTTP:
+#   metrics-docker-info.rb -H localhost:2375
 #
 #   See metrics-docker-info.rb --help for full usage flags
 #
@@ -51,12 +51,6 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
          default: '/var/run/docker.sock'
-
-  option :docker_protocol,
-         description: 'http or unix',
-         short: '-p PROTOCOL',
-         long: '--protocol PROTOCOL',
-         default: 'unix'
 
   def run
     @timestamp = Time.now.to_i

--- a/bin/metrics-docker-info.rb
+++ b/bin/metrics-docker-info.rb
@@ -49,8 +49,7 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :docker_host,
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          short: '-H DOCKER_HOST',
-         long: '--docker-host DOCKER_HOST',
-         default: '/var/run/docker.sock'
+         long: '--docker-host DOCKER_HOST'
 
   def run
     @timestamp = Time.now.to_i

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -19,13 +19,13 @@
 #
 # USAGE:
 #   Gather stats from all containers on a host using socket:
-#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock
+#   metrics-docker-stats.rb -H /var/run/docker.sock
 #
-#   Gather stats from all containers on a host using TCP:
-#   metrics-docker-stats.rb -p http -H localhost:2375
+#   Gather stats from all containers on a host using HTTP:
+#   metrics-docker-stats.rb -H localhost:2375
 #
 #   Gather stats from a specific container using socket:
-#   metrics-docker-stats.rb -p unix -H /var/run/docker.sock -c 5bf1b82382eb
+#   metrics-docker-stats.rb -H /var/run/docker.sock -N 5bf1b82382eb
 #
 #   See metrics-docker-stats.rb --help for full usage flags
 #
@@ -62,8 +62,8 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   option :container,
          description: 'Name of container to collect metrics for',
-         short: '-c CONTAINER',
-         long: '--container CONTAINER',
+         short: '-N CONTAINER',
+         long: '--container-name CONTAINER',
          default: ''
 
   option :docker_host,
@@ -71,12 +71,6 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-H DOCKER_HOST',
          long: '--docker-host DOCKER_HOST',
          default: '127.0.0.1:2375'
-
-  option :docker_protocol,
-         description: 'http or unix',
-         short: '-p PROTOCOL',
-         long: '--protocol PROTOCOL',
-         default: 'http'
 
   option :friendly_names,
          description: 'use friendly name if available',

--- a/bin/metrics-docker-stats.rb
+++ b/bin/metrics-docker-stats.rb
@@ -69,8 +69,7 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :docker_host,
          description: 'Docker API URI. https://host, https://host:port, http://host, http://host:port, host:port, unix:///path',
          short: '-H DOCKER_HOST',
-         long: '--docker-host DOCKER_HOST',
-         default: '127.0.0.1:2375'
+         long: '--docker-host DOCKER_HOST'
 
   option :friendly_names,
          description: 'use friendly name if available',
@@ -80,8 +79,8 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: false
 
   option :name_parts,
-         description: 'Partial names by spliting and returning at index(es). \
-                       eg. -m 3,4 my-docker-container-process_name-b2ffdab8f1aceae85300 for process_name.b2ffdab8f1aceae85300',
+         description: 'Partial names by spliting and returning at index(es).
+         eg. -m 3,4 my-docker-container-process_name-b2ffdab8f1aceae85300 for process_name.b2ffdab8f1aceae85300',
          short: '-m index',
          long: '--match index'
 
@@ -93,8 +92,8 @@ class DockerStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   option :environment_tags,
          description: 'Name of environment variables on each container to be appended to metric name, separated by commas',
-         short: '-e ENVIRONMENT_VARIABLES',
-         long: '--environment-tags ENVIRONMENT_VARIABLES'
+         short: '-e ENV_VARS',
+         long: '--environment-tags ENV_VARS'
 
   option :ioinfo,
          description: 'enable IO Docker metrics',

--- a/lib/sensu-plugins-docker/client_helpers.rb
+++ b/lib/sensu-plugins-docker/client_helpers.rb
@@ -1,18 +1,60 @@
 require 'net_http_unix'
+require 'json'
 
-def create_docker_client
-  client = nil
-  if config[:docker_host][0] == '/'
-    host = 'unix://' + config[:docker_host]
-    client = NetX::HTTPUnix.new(host)
-  else
-    split_host = config[:docker_host].split ':'
-    client = if split_host.length == 2
-               NetX::HTTPUnix.new(split_host[0], split_host[1])
-             else
-               NetX::HTTPUnix.new(config[:docker_host], 2375)
-             end
+class DockerApi
+  def initialize(uri = nil)
+    @client = nil
+    @docker_uri = uri || ENV['DOCKER_URL'] || ENV['DOCKER_HOST'] || '/var/run/docker.sock'
+    if @docker_uri.sub!(%r{^(unix://)?/}, '')
+      @docker_uri = 'unix:///' + @docker_uri
+      @client = NetX::HTTPUnix.new(@docker_uri)
+    else
+      protocol = %r{^(https?|tcp)://}.match(@docker_uri) || 'http://'
+      @docker_uri.sub!(protocol.to_s, '')
+      split_host = @docker_uri.split ':'
+      @client = if split_host.length == 2
+                  NetX::HTTPUnix.new("#{protocol}#{split_host[0]}", split_host[1])
+                else
+                  NetX::HTTPUnix.new("#{protocol}#{@docker_uri}", 2375)
+                end
+    end
+    @client.start
   end
 
-  client
+  def uri
+    @docker_uri
+  end
+
+  def call(path, halt = true, limit = 10)
+    raise ArgumentError, "HTTP redirect too deep. Last url called : #{path}" if limit.zero?
+    if %r{^unix:///} =~ @docker_uri
+      request = Net::HTTP::Get.new path.to_s
+    else
+      uri = URI("#{@docker_uri}#{path}")
+      request = Net::HTTP::Get.new uri.request_uri
+    end
+    response = @client.request(request)
+    case response
+    when Net::HTTPSuccess     then response
+    when Net::HTTPRedirection then call(response['location'], true, limit - 1)
+    else
+      return response.error! unless halt == false
+      return response
+    end
+  end
+
+  def parse(path, halt = true, limit = 10)
+    parsed = parse_json(call(path, halt, limit))
+    parsed
+  end
+end
+
+def parse_json(response)
+  parsed = nil
+  begin
+    parsed = JSON.parse(response.read_body)
+  rescue JSON::ParserError => e
+    raise "JSON Error: #{e.inspect}"
+  end
+  parsed
 end

--- a/sensu-plugins-docker.gemspec
+++ b/sensu-plugins-docker.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsDocker::Version::VER_STRING
 
-  s.add_runtime_dependency 'docker-api',    '1.21.0'
   s.add_runtime_dependency 'sensu-plugin',  '~> 2.0'
   s.add_runtime_dependency 'sys-proctable', '0.9.8'
   s.add_runtime_dependency 'net_http_unix', '0.2.2'


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [X] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes (didn't touch this offense _"sensu-plugins-docker.gemspec:7:1: C: Block has too many lines. [36/25]"_)

- [ ] Existing tests pass (didn't touch this offense _"sensu-plugins-docker.gemspec:7:1: C: Block has too many lines. [36/25]"_)


#### Purpose

- completely suppress the need to have docker-cli on host ( "docker ps" is not executed anymore )
- defined a class to be used in all docker checks / metrics
- check-container-logs.rb: have the possibility to analyze all logs without the need to give a container name + extras
- metrics-docker-container.rb : add friendly name option
- Maybe correct #21 if i understood it well

#### Known Compatibility Issues

- The default host is not 127.0.0.1:2375 anymore but is defined by the arg provided to DockerApi.new first (:config[docker_host]), then by DOCKER_URL env then DOCKER_HOST env then /var/run/docker.sock. Maybe some people used 127.0.0.1:2375, but i think than most of people use /var/run/docker.sock
- check-container-logs.rb : don't check logs generated with a tty anymore. logs are reversed for the check (most recent first)

#### Personal comments 
First ruby dev
First pull request
Sorry if it is not done the way it should be, feel free to guide me if i need to correct some things.

Best regards