### PR TITLE
Add option for task oriented containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ### Added
  - intergration test for container check
+ - check-container.rb: -x (--allow-exited) to avoid raising alerts when container exited without error, useful for task oriented containers monitoring.
 
 ## [3.0.0] - 2018-02-17
 ### Breaking Changes

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -15,4 +15,9 @@ gem install sensu-plugins-docker-*.gem
 
 # start container for testing
 
-docker run --name test -d --rm alpine sh -c 'while true; do sleep 1; done'
+docker run --name test_running -d --rm alpine sh -c 'while true; do sleep 1; done'
+docker run --name test_exited_ok -d alpine sh -c 'exit 0'
+docker run --name test_exited_fail -d alpine sh -c 'exit 1'
+
+# for debugging
+docker ps -a

--- a/test/integration/helpers/serverspec/check-container_spec.rb
+++ b/test/integration/helpers/serverspec/check-container_spec.rb
@@ -11,7 +11,27 @@ describe 'ruby environment' do
   it_behaves_like 'ruby checks', check
 end
 
-describe command("#{check} -N test") do
+describe command("#{check} -N test_running") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/CheckDockerContainer OK: test is running on unix:\/\/\/var\/run\/docker.sock./) }
+  its(:stdout) { should match(/CheckDockerContainer OK: test_running is running on unix:\/\/\/var\/run\/docker.sock./) }
+end
+
+describe command("#{check} -x -N test_running") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/CheckDockerContainer OK: test_running is running on unix:\/\/\/var\/run\/docker.sock./) }
+end
+
+describe command("#{check} -N test_exited_ok") do
+  its(:exit_status) { should eq 2 }
+  its(:stdout) { should match(/CheckDockerContainer CRITICAL: test_exited_ok is exited on unix:\/\/\/var\/run\/docker.sock./) }
+end
+
+describe command("#{check} -x -N test_exited_ok") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/CheckDockerContainer OK: test_exited_ok has exited without error on unix:\/\/\/var\/run\/docker.sock./) }
+end
+
+describe command("#{check} -x -N test_exited_fail") do
+  its(:exit_status) { should eq 2 }
+  its(:stdout) { should match(/CheckDockerContainer CRITICAL: test_exited_fail has exited with status code 1 on unix:\/\/\/var\/run\/docker.sock./) }
 end


### PR DESCRIPTION
In some cases docker containers would be used on demand or started
periodically to execute certain tasks. Option -x would allow to monitor
them and only raise alerts if they have exited with error (status code
different from zero).