### PR TITLE
Prevent check-container-logs.rb failing on a nil string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+ - check-container-logs.rb: fix nil.gsub condition on empty log lines
 
 ## [3.1.0] - 2018-05-07
 ### Added

--- a/bin/check-container-logs.rb
+++ b/bin/check-container-logs.rb
@@ -138,7 +138,7 @@ class ContainerLogChecker < Sensu::Plugin::Check::CLI
     lines = raw_logs.split("\n")
     lines.map! do |line|
       # Check only logs generated with the 8 bits control
-      if !line.nil? && /^(0|1|2)000$/ =~ line.byteslice(0, 4).unpack('C*').join('')
+      if !line.nil? && line.bytesize > 8 && /^(0|1|2)000$/ =~ line.byteslice(0, 4).unpack('C*').join('')
         # Remove the first 8 bits and ansii colors too
         line.byteslice(8, line.bytesize).gsub(/\x1b\[[\d;]*?m/, '')
       end


### PR DESCRIPTION
## Pull Request Checklist
#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] ~Update README with any necessary configuration snippets~

- [ ] ~Binstubs are created if needed~

- [ ] ~RuboCop passes~

- [ ] ~Existing tests pass~

#### Purpose

When chopping the binary headers from docker log response, empty log lines lead to a `nil.gsub` due to how `String::byteslice` works. This PR filters that condition properly.

